### PR TITLE
allow parameters to be quoted so that spaces between parameters will …

### DIFF
--- a/t
+++ b/t
@@ -20,7 +20,7 @@ _t_do() {
 # Clock in to the last project if no project is given
 _t_in() {
   [ ! "$1" ] && set -- "$@" "$(_t_last)"
-  echo i `date '+%Y-%m-%d %H:%M:%S'` $* >> "$timelog"
+  echo i `date '+%Y-%m-%d %H:%M:%S'` "$*" >> "$timelog"
 }
 
 # Clock out

--- a/t
+++ b/t
@@ -25,13 +25,13 @@ _t_in() {
 
 # Clock out
 _t_out() {
-  echo o `date '+%Y-%m-%d %H:%M:%S'` $* >> "$timelog"
+  echo o `date '+%Y-%m-%d %H:%M:%S'` "$*" >> "$timelog"
 }
 
 # switch projects
 _t_sw() {
   echo o `date '+%Y-%m-%d %H:%M:%S'` >> "$timelog"
-  echo i `date '+%Y-%m-%d %H:%M:%S'` $* >> "$timelog"
+  echo i `date '+%Y-%m-%d %H:%M:%S'` "$*" >> "$timelog"
 }
 
 # Show the currently clocked-in project


### PR DESCRIPTION
allow parameters to be quoted so that spaces between parameters will be respected

if you use the ledger bal command summarised times will be displayed for each category
if there is a single space between. the category and a comment, the comment is treated as part of the category, whereas if there are two or more spaces, the comment is not considered
with this change it is possible to do this -- t in "my:simple:cat.  a comment here" and the spaces will be respected
